### PR TITLE
fixed size dicts and sets should have elements

### DIFF
--- a/src/prng/random.gleam
+++ b/src/prng/random.gleam
@@ -590,7 +590,8 @@ pub fn fixed_size_dict(
   values values: Generator(v),
   of size: Int,
 ) {
-  do_fixed_size_dict(keys, values, size, 0, 0, dict.new())
+  int.max(size, 0)
+  |> do_fixed_size_dict(keys, values, _, 0, 0, dict.new())
 }
 
 fn do_fixed_size_dict(
@@ -606,7 +607,7 @@ fn do_fixed_size_dict(
   let has_required_size = unique_keys == size
   use <- bool.guard(when: has_required_size, return: constant(acc))
 
-  let has_reached_maximum_attempts = consecutive_attempts <= 10
+  let has_reached_maximum_attempts = consecutive_attempts >= 10
   use <- bool.guard(when: has_reached_maximum_attempts, return: constant(acc))
   // ^-- if after 10 tries, we couldn't still generate a key that doesn't
   //     already exist, then we give up and return a map smaller than required
@@ -651,7 +652,8 @@ pub fn fixed_size_set(
   from generator: Generator(a),
   of size: Int,
 ) -> Generator(Set(a)) {
-  do_fixed_size_set(generator, size, 0, 0, set.new())
+  int.max(size, 0)
+  |> do_fixed_size_set(generator, _, 0, 0, set.new())
 }
 
 fn do_fixed_size_set(
@@ -666,7 +668,7 @@ fn do_fixed_size_set(
   let has_required_size = unique_items == size
   use <- bool.guard(when: has_required_size, return: constant(acc))
 
-  let has_reached_maximum_attempts = consecutive_attempts <= 10
+  let has_reached_maximum_attempts = consecutive_attempts >= 10
   use <- bool.guard(when: has_reached_maximum_attempts, return: constant(acc))
   // ^-- if after 10 tries, we couldn't still generate an item that doesn't
   //     already exist in the set, then we give up and return a set smaller than

--- a/test/prng/random_test.gleam
+++ b/test/prng/random_test.gleam
@@ -102,7 +102,8 @@ pub fn fixed_size_dict_generates_maps_of_at_most_the_given_length_test() {
 
   let maps = random.fixed_size_dict(keys, values, of: 10)
   use map <- do_test(for_all: maps)
-  list.length(dict.keys(map)) <= 10
+  let length = list.length(dict.keys(map))
+  0 < length && length <= 10
 }
 
 pub fn dict_returns_maps_in_range_0_32_test() {
@@ -122,7 +123,8 @@ pub fn fixed_size_set_generates_sets_of_at_most_the_given_length_test() {
 
   let sets = random.fixed_size_set(values, of: 10)
   use set <- do_test(for_all: sets)
-  set.size(set) <= 10
+  let size = set.size(set)
+  0 < size && size <= 10
 }
 
 pub fn set_returns_sets_in_range_0_32_test() {


### PR DESCRIPTION
Had to also adjust the minimum sizes since this would never return otherwise.
Also added some clauses for the tests that should catch this in the future.