### PR TITLE
Update docs for random weighted function

### DIFF
--- a/src/prng/random.gleam
+++ b/src/prng/random.gleam
@@ -410,7 +410,7 @@ pub fn try_uniform(options: List(a)) -> Result(Generator(a), Nil) {
 /// times like this:
 ///
 /// ```gleam
-/// let loaded_coin = random.weighted(#(Heads, 0.75), [#(Tails, 0.25)])
+/// let loaded_coin = random.weighted(#(0.75, Heads), [#(0.25, Tails)])
 /// ```
 ///
 /// In this example the weights add up to 1, but you could use any number: the


### PR DESCRIPTION
In the docs for `random.weighted`, the probabilities and the items were reversed in the tuples.  This commit addresses that.