### PR TITLE
Upgrades deprecated `Iterator` in favour of `Yielder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@
 > - 📓 is for documentation-related changes
 > - 🐛 is for bug fixes
 
+## v4.0.0 - Unreleased
+
+- 💥 Remove deprecated `Iterator` in favor of `Yielder` from `gleam_yielder`, and rename functions accordingly.
+- 💥 `to_random_iterator` becomes `to_random_yielder`.
+- 💥 `to_iterator` becomes `to_yielder`.
+
 ## v3.0.3 - 2024-04-22
 
 - 💡 Rename ffi modules to avoid conflicts on the Erlang target.

--- a/gleam.toml
+++ b/gleam.toml
@@ -6,8 +6,9 @@ licences = ["Apache-2.0"]
 repository = { type = "github", user = "giacomocavalieri", repo = "prng" }
 
 [dependencies]
-gleam_stdlib = ">= 0.34.0 and < 2.0.0"
+gleam_stdlib = ">= 0.45.0 and < 2.0.0"
 gleam_bitwise = ">= 1.3.0 and < 2.0.0"
+gleam_yielder = ">= 1.1.0 and < 2.0.0"
 
 [dev-dependencies]
 gleeunit = ">= 1.0.0 and < 2.0.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "prng"
-version = "3.0.3"
+version = "4.0.0"
 description = "A Pure Random Number Generator"
 
 licences = ["Apache-2.0"]

--- a/manifest.toml
+++ b/manifest.toml
@@ -3,11 +3,13 @@
 
 packages = [
   { name = "gleam_bitwise", version = "1.3.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_bitwise", source = "hex", outer_checksum = "B36E1D3188D7F594C7FD4F43D0D2CE17561DE896202017548578B16FE1FE9EFC" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
+  { name = "gleam_yielder", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_yielder", source = "hex", outer_checksum = "8E4E4ECFA7982859F430C57F549200C7749823C106759F4A19A78AEA6687717A" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
 ]
 
 [requirements]
 gleam_bitwise = { version = ">= 1.3.0 and < 2.0.0" }
-gleam_stdlib = { version = ">= 0.34.0 and < 2.0.0" }
+gleam_stdlib = { version = ">= 0.45.0 and < 2.0.0" }
+gleam_yielder = { version = ">= 1.1.0 and < 2.0.0" }
 gleeunit = { version = ">= 1.0.0 and < 2.0.0" }

--- a/src/prng/random.gleam
+++ b/src/prng/random.gleam
@@ -48,14 +48,14 @@
 ////   <td>
 ////     <a href="#step">step</a>,
 ////     <a href="#sample">sample</a>,
-////     <a href="#to_iterator">to_iterator</a>
+////     <a href="#to_yielder">to_yielder</a>
 ////   </td>
 //// </tr>
 //// <tr>
 ////   <td>Getting truly random values out of generators</td>
 ////   <td>
 ////     <a href="#random_sample">random_sample</a>,
-////     <a href="#to_random_iterator">to_random_iterator</a>
+////     <a href="#to_random_yielder">to_random_yielder</a>
 ////   </td>
 //// </tr>
 //// </table>
@@ -66,12 +66,12 @@ import gleam/bool
 import gleam/dict.{type Dict}
 import gleam/float
 import gleam/int
-import gleam/iterator.{type Iterator}
 import gleam/list
 import gleam/order.{type Order, Eq, Gt, Lt}
 import gleam/pair
 import gleam/set.{type Set}
 import gleam/string
+import gleam/yielder.{type Yielder}
 import prng/seed.{type Seed}
 
 // DEFINITION ------------------------------------------------------------------
@@ -136,8 +136,8 @@ pub opaque type Generator(a) {
 /// subsequent calls to `step` to get other random values.
 ///
 /// Stepping a generator by hand can be quite cumbersome, so I recommend you
-/// try [`to_iterator`](#to_iterator),
-/// [`to_random_iterator`](#to_random_iterator), or [`sample`](#sample) instead.
+/// try [`to_yielder`](#to_yielder),
+/// [`to_random_yielder`](#to_random_yielder), or [`sample`](#sample) instead.
 ///
 /// ## Examples
 ///
@@ -189,11 +189,11 @@ pub fn sample(from generator: Generator(a), with seed: Seed) -> a {
 /// ```
 ///
 pub fn random_sample(generator: Generator(a)) -> a {
-  // ⚠️ [ref:iterator_infinite] this is based on the assumption that, a sampled
+  // ⚠️ [ref:yielder_infinite] this is based on the assumption that, a sampled
   // generator will always yield at least one value. This is true since the
-  // `to_iterator` implementation produces an infinite stream of values.
+  // `to_yielder` implementation produces an infinite stream of values.
   // However, if the implementation were to change this piece of code may break!
-  let assert Ok(result) = iterator.first(to_random_iterator(generator))
+  let assert Ok(result) = yielder.first(to_random_yielder(generator))
   result
 }
 
@@ -205,10 +205,10 @@ pub fn random_sample(generator: Generator(a)) -> a {
 /// function.
 ///
 /// If you want to have control over the initial seed used to get the infinite
-/// sequence of values, you can use `to_iterator`.
+/// sequence of values, you can use `to_yielder`.
 ///
-pub fn to_random_iterator(from generator: Generator(a)) -> Iterator(a) {
-  to_iterator(generator, seed.random())
+pub fn to_random_yielder(from generator: Generator(a)) -> Yielder(a) {
+  to_yielder(generator, seed.random())
 }
 
 /// Turns the given generator into an infinite stream of random values generated
@@ -218,15 +218,15 @@ pub fn to_random_iterator(from generator: Generator(a)) -> Iterator(a) {
 /// infinite sequence.
 ///
 /// If you don't care about the initial seed and reproducibility is not your
-/// goal, you can use `to_random_iterator` which works like this function and
+/// goal, you can use `to_random_yielder` which works like this function and
 /// randomly picks the initial seed.
 ///
-pub fn to_iterator(generator: Generator(a), seed: Seed) -> Iterator(a) {
-  use seed <- iterator.unfold(from: seed)
+pub fn to_yielder(generator: Generator(a), seed: Seed) -> Yielder(a) {
+  use seed <- yielder.unfold(from: seed)
   let #(value, new_seed) = step(generator, seed)
-  // [tag:iterator_infinite] this will generate an infinite stream of values
-  // since it never returns an `iterator.Done`
-  iterator.Next(element: value, accumulator: new_seed)
+  // [tag:yielder_infinite] this will generate an infinite stream of values
+  // since it never returns an `yielder.Done`
+  yielder.Next(element: value, accumulator: new_seed)
 }
 
 // BASIC FFI BUILDERS ----------------------------------------------------------

--- a/test/prng/random_test.gleam
+++ b/test/prng/random_test.gleam
@@ -1,7 +1,7 @@
 import gleam/dict
-import gleam/iterator
 import gleam/list
 import gleam/set
+import gleam/yielder
 import gleeunit/should
 import prng/random.{type Generator}
 import prng/seed
@@ -9,11 +9,11 @@ import prng/seed
 fn do_test(for_all generator: Generator(a), that property: fn(a) -> Bool) -> Nil {
   let number_of_samples = 1000
   let samples =
-    random.to_random_iterator(generator)
-    |> iterator.take(number_of_samples)
-    |> iterator.to_list
+    random.to_random_yielder(generator)
+    |> yielder.take(number_of_samples)
+    |> yielder.to_list
 
-  // The iterator should be infinite, so we _must_ always have 1000 samples
+  // The yielder should be infinite, so we _must_ always have 1000 samples
   list.length(samples)
   |> should.equal(number_of_samples)
 
@@ -29,13 +29,13 @@ fn behaves_the_same(gen1: Generator(a), gen2: Generator(a)) -> Nil {
     |> random.random_sample
 
   let samples1 =
-    random.to_iterator(gen1, seed)
-    |> iterator.take(1000)
-    |> iterator.to_list
+    random.to_yielder(gen1, seed)
+    |> yielder.take(1000)
+    |> yielder.to_list
   let samples2 =
-    random.to_iterator(gen2, seed)
-    |> iterator.take(1000)
-    |> iterator.to_list
+    random.to_yielder(gen2, seed)
+    |> yielder.take(1000)
+    |> yielder.to_list
 
   should.equal(samples1, samples2)
 }


### PR DESCRIPTION
## Context

`gleam_stdlib` 0.45 deprecates `Iterator` from `gleam/iterator`, in favour of `gleam_yielder`.

## Changes

- `Iterator` is changed to `Yielder`.
- Every functions named `to_[...]_iterator` are renamed `to_[...]_yielder`.
- Changelog is updated with new changes.
- `gleam.toml` is updated with new breaking version (4.0.0) and requires `gleam_stdlib` as 0.45 for minimal version.