### PR TITLE
Support encoding and decoding a seed

### DIFF
--- a/src/prng/seed.gleam
+++ b/src/prng/seed.gleam
@@ -18,3 +18,15 @@ pub fn new(int: Int) -> Seed
 pub fn random() -> Seed {
   new(int.random(4_294_967_296))
 }
+
+/// Encodes a seed.
+///
+@external(erlang, "prng_ffi", "encode_seed")
+@external(javascript, "../prng_ffi.mjs", "encode_seed")
+pub fn encode_seed(seed: Seed) -> String
+
+/// Decodes a seed.
+///
+@external(erlang, "prng_ffi", "decode_seed")
+@external(javascript, "../prng_ffi.mjs", "decode_seed")
+pub fn decode_seed(seed: String) -> Seed

--- a/src/prng_ffi.erl
+++ b/src/prng_ffi.erl
@@ -1,5 +1,5 @@
 -module(prng_ffi).
--export([new_seed/1, seed_to_int/1, random_int/3, random_float/3]).
+-export([new_seed/1, seed_to_int/1, random_int/3, random_float/3, encode_seed/1, decode_seed/1]).
 
 new_seed(From) ->
     {State0, Step} = next({0, 1_013_904_223}),
@@ -73,3 +73,12 @@ truncate_32(Number, to_int) ->
 truncate_32(Number, to_bit) ->
     Truncated = truncate_32(Number, to_int),
     <<Truncated:32/integer>>.
+
+encode_seed(Decoded) ->
+    {State, Step} = Decoded,
+    base64:encode(iolist_to_binary([integer_to_list(State), ",", integer_to_list(Step)])).
+
+decode_seed(Encoded) ->
+    Decoded = binary_to_list(base64:decode(Encoded)),
+    [State, Step] = string:split(Decoded, ","),
+    {list_to_integer(State), list_to_integer(Step)}.

--- a/src/prng_ffi.mjs
+++ b/src/prng_ffi.mjs
@@ -5,7 +5,6 @@ export function new_seed(from) {
   const new_state = (state + from) >>> 0;
   return next([new_state, step]);
 }
-
 function next(seed) {
   const [state, step] = seed;
   const new_state = (state * 1_664_525 + step) >>> 0;
@@ -49,4 +48,20 @@ export function random_float(seed, from, to) {
   const range = to - from;
   const scaled = value * range + from;
   return [scaled, next(new_seed)];
+}
+
+export function encode_seed(seed) {
+  const [state, step] = seed;
+  const new_state = (state + from) >>> 0;
+  return next([new_state, step]);
+}
+
+export function encode_seed(decoded) {
+  const [state, step] = decoded;
+  return btoa(`${state},${step}`); 
+}
+
+export function decode_seed(encoded) {
+  const [state, step] = atob(encoded).split(',').map(Number);
+  return [state, step];
 }

--- a/src/prng_ffi.mjs
+++ b/src/prng_ffi.mjs
@@ -50,18 +50,12 @@ export function random_float(seed, from, to) {
   return [scaled, next(new_seed)];
 }
 
-export function encode_seed(seed) {
-  const [state, step] = seed;
-  const new_state = (state + from) >>> 0;
-  return next([new_state, step]);
-}
-
 export function encode_seed(decoded) {
   const [state, step] = decoded;
-  return btoa(`${state},${step}`); 
+  return btoa(`${state},${step}`);
 }
 
 export function decode_seed(encoded) {
-  const [state, step] = atob(encoded).split(',').map(Number);
+  const [state, step] = atob(encoded).split(",").map(Number);
   return [state, step];
 }

--- a/test/prng/seed_test.gleam
+++ b/test/prng/seed_test.gleam
@@ -1,0 +1,32 @@
+import gleeunit/should
+import prng/random
+import prng/seed
+
+pub fn roundtrip_test() {
+  let random_seed = seed.random()
+  let encoded_seed = seed.encode_seed(random_seed)
+  let decoded_seed = seed.decode_seed(encoded_seed)
+  
+  let generator = random.int(1, 6)
+  
+  let #(left_value, _random_next_seed) = random.step(generator, random_seed)
+  let #(right_value, _new_next_seed) = random.step(generator, decoded_seed)
+  
+  should.equal(left_value, right_value)
+}
+
+pub fn continuation_test() {
+  let random_seed = seed.random()
+  
+  let generator = random.int(1, 6)
+  
+  let #(_value, next_seed) = random.step(generator, random_seed)
+  
+  let encoded_seed = seed.encode_seed(next_seed)
+  let decoded_seed = seed.decode_seed(encoded_seed)
+  
+  let #(left_value, _next_seed2) = random.step(generator, next_seed)
+  let #(right_value, _next_seed3) = random.step(generator, decoded_seed)
+  
+  should.equal(left_value, right_value)
+}


### PR DESCRIPTION
I had a need for interrupting the generators and continue from the seed I left off with. The encoded value can be persisted and decoded at a later time. The use of base64 is up for debate.