### PR TITLE
Add signed flag for expand_to_64

### DIFF
--- a/src/prng_ffi.erl
+++ b/src/prng_ffi.erl
@@ -61,7 +61,7 @@ expand_to_64(Number) ->
     <<First:1, _:31/bitstring>> = NumberBits,
     Pad =
         case First of
-            1 -> <<-1:32>>;
+            1 -> <<-1:32/signed-integer>>;
             _ -> <<0:32>>
         end,
     <<Result:64/signed-integer>> = <<Pad/bitstring, NumberBits/bitstring>>,


### PR DESCRIPTION
On the master branch of OTP, this line is raising a warning:

```
/Users/jtdowney/code/prng/build/dev/erlang/prng/_gleam_artefacts/prng_ffi.erl:64:20: Warning: integer value outside range of binary segment will be truncated.
The value -1 cannot be encoded as 32 bits unsigned.
Compile directive 'nowarn_truncated_integer' can be used to suppress this
warning.
%   64|             1 -> <<-1:32>>;
%     |                    ^
```